### PR TITLE
Add .pdm-python file to Python gitignore template

### DIFF
--- a/templates/Python.gitignore
+++ b/templates/Python.gitignore
@@ -108,6 +108,10 @@ ipython_config.py
 #   in version control.
 #   https://pdm.fming.dev/#use-with-ide
 .pdm.toml
+#   .pdm-python contains information about the local Python interpreter and shouldn't be included
+#   in version control.
+#   https://pdm-project.org/latest/usage/project/#working-with-version-control
+.pdm-python
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/


### PR DESCRIPTION
Per the PDM documentation, the .pdm-python file should not be committed.

https://pdm-project.org/latest/usage/project/#working-with-version-control

# Pull Request

Thank you for contributing to @toptal/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [X] Template - Update existing `.gitignore` template

## Details

Relevant information from [the PDM documentation](https://pdm-project.org/latest/usage/project/#working-with-version-control):

> You **must** commit the `pyproject.toml` file. You **should** commit the `pdm.lock` and `pdm.toml` file. **Do not** commit the `.pdm-python` file.

and

> `.pdm-python` stores the **Python path** used by the **current** project and doesn't need to be shared.